### PR TITLE
getItems should be a static method

### DIFF
--- a/lib/FxPatcher/Util/Installer.php
+++ b/lib/FxPatcher/Util/Installer.php
@@ -5,7 +5,7 @@ namespace FxPatcher\Util;
 use Pimcore\Model\Cache as PimcoreCache;
 
 class Installer {
-	public function getItems(){
+	public static function getItems(){
 		return array(
 			'\FxPatcher\Util\Installer\InstallItem\Config',
 			'\FxPatcher\Util\Installer\InstallItem\Directory'


### PR DESCRIPTION
Since getItems is called using `self::getItems()` in Installer.php, it should be a public static method to avoid PHP warnings
